### PR TITLE
Update toggle header binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ stop build - Shift F7
 goto definition - Shift F8
 take screenshot - Shift F9
 toggle eye mouse - Shift F10
-
-TODO: toggle header could should use Shift F11 (currently set to Alt-O)
+toggle header - Shift F11
 
 # Mac
 

--- a/kinesis layout/1_qwerty.txt
+++ b/kinesis layout/1_qwerty.txt
@@ -106,7 +106,7 @@
 {kp-q}>{speed5}{-rwin}{-lshift}{f}{+lshift}{+rwin}
 {kp-w}>{speed5}{-rwin}{f}{+rwin}
 {kp-r}>{speed5}{-lctrl}{up}{+lctrl}
-{kp-t}>{speed5}{-lalt}{o}{+lalt}
+{kp-t}>{speed5}{-lshift}{f11}{+lshift}
 {kp-y}>{speed5}{-lshift}{'}{+lshift}
 {kp7}>{speed5}{-rshift}{=}{+rshift}
 {kp8}>{speed5}{hyphen}

--- a/kinesis layout/w_qwerty.txt
+++ b/kinesis layout/w_qwerty.txt
@@ -103,7 +103,7 @@
 {kp-q}>{speed5}{-rctrl}{=}{+rctrl}
 {kp-w}>{speed5}{-rctrl}{f}{+rctrl}
 {kp-r}>{speed5}{-lwin}{tab}{+lwin}
-{kp-t}>{speed5}{-lalt}{o}{+lalt}
+{kp-t}>{speed5}{-lshift}{f11}{+lshift}
 {kp-y}>{speed5}{-lshift}{'}{+lshift}
 {kp7}>{speed5}{-rshift}{=}{+rshift}
 {kp8}>{speed5}{hyphen}


### PR DESCRIPTION
## Summary
- document keyboard binding for toggling headers
- update kinesis layouts to use `Shift+F11` instead of `Alt+O`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68606b4889a4832da619f2f7f4aecbba