### PR TITLE
Add cross-platform CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies (ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y neovim lua5.4 jq
+      - name: Install dependencies (macos)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install neovim lua jq
+      - name: Install dependencies (windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install neovim lua jq -y
+        shell: pwsh
+      - name: Lua syntax check
+        run: luac -p hammerspoon/init.lua
+        shell: bash
+      - name: Validate JSON files
+        run: |
+          grep -v '^\s*//' vscode/keybindings.json | jq empty
+          grep -v '^\s*//' vscode/settings.json | jq empty
+        shell: bash
+      - name: Start Neovim
+        run: |
+          nvim --headless +q 2>nvim.log
+          if [ -s nvim.log ]; then
+            cat nvim.log
+            exit 1
+          fi
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y neovim lua5.4 jq
+          sudo apt-get install -y neovim lua5.4 jq chezmoi
       - name: Install dependencies (macos)
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install neovim lua jq
+          brew install neovim lua jq chezmoi
       - name: Install dependencies (windows)
         if: runner.os == 'Windows'
         run: |
-          choco install neovim lua jq -y
+          choco install neovim lua jq chezmoi -y
         shell: pwsh
       - name: Lua syntax check
         run: luac -p hammerspoon/init.lua
@@ -34,6 +34,14 @@ jobs:
         run: |
           grep -v '^\s*//' vscode/keybindings.json | jq empty
           grep -v '^\s*//' vscode/settings.json | jq empty
+        shell: bash
+      - name: Apply dotfiles with chezmoi
+        run: |
+          chezmoi init --source=. --apply
+          if [ -n "$(chezmoi status --porcelain)" ]; then
+            chezmoi status
+            exit 1
+          fi
         shell: bash
       - name: Start Neovim
         run: |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ and performs several checks:
    contains no syntax errors.
 2. **JSON validation** – `jq` validates `vscode/keybindings.json` and
    `vscode/settings.json`.
-3. **Neovim startup** – Neovim is launched headless and the run fails if any
+3. **chezmoi apply** – the repository is applied with `chezmoi` from the
+   checked-out branch and the run fails if any files remain pending.
+4. **Neovim startup** – Neovim is launched headless and the run fails if any
    errors are printed during startup.
 
 Package installation is handled with the platform package manager:
@@ -191,4 +193,5 @@ Package installation is handled with the platform package manager:
 - **macOS** – `brew`
 - **Windows** – `choco`
 
-If any step fails the CI job exits with an error.
+If any step fails the CI job exits with an error. `chezmoi` and Neovim are
+installed via each platform's package manager alongside Lua and `jq`.

--- a/README.md
+++ b/README.md
@@ -171,3 +171,24 @@ Copy-Item -Path .\* -Destination 'D:\active\' -Recurse -Force -Verbose
 ```
 
 Note: I've had issues using the Mac version of the Kinesis app where it totally corrupts the drive - so just use Windows.
+
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow that checks the configuration
+files on every push or pull request. The job runs on Linux, macOS and Windows
+and performs several checks:
+
+1. **Lua syntax** – `hammerspoon/init.lua` is compiled with `luac` to ensure it
+   contains no syntax errors.
+2. **JSON validation** – `jq` validates `vscode/keybindings.json` and
+   `vscode/settings.json`.
+3. **Neovim startup** – Neovim is launched headless and the run fails if any
+   errors are printed during startup.
+
+Package installation is handled with the platform package manager:
+
+- **Ubuntu** – `apt`
+- **macOS** – `brew`
+- **Windows** – `choco`
+
+If any step fails the CI job exits with an error.

--- a/vscode/keybindings.json
+++ b/vscode/keybindings.json
@@ -37,5 +37,5 @@
         "key": "pageup",
         "command": "scrollPageUp",
         "when": "textInputFocus"
-    },
+    }
 ]


### PR DESCRIPTION
## Summary
- expand CI workflow to support Ubuntu, macOS, and Windows
- document platform-specific package installation
- fix trailing comma in `keybindings.json`

## Testing
- `grep -v '^\s*//' vscode/keybindings.json | jq empty`
- `grep -v '^\s*//' vscode/settings.json | jq empty`
- `luac -p hammerspoon/init.lua` *(fails: command not found)*
- `nvim --headless +q` *(fails: command not found)*
- `sudo apt-get update` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_686a85b98228832da2507fb77899f734