### PR TITLE
Add chezmoi CI workflow

### DIFF
--- a/.github/workflows/chezmoi.yml
+++ b/.github/workflows/chezmoi.yml
@@ -1,0 +1,27 @@
+name: Chezmoi Validation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install chezmoi (Linux/Mac)
+        if: runner.os != 'Windows'
+        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+      - name: Install chezmoi (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install chezmoi -y
+      - name: Initialize dotfiles
+        shell: bash
+        run: chezmoi init --source "$GITHUB_WORKSPACE" --branch "$GITHUB_REF_NAME"
+      - name: Validate
+        shell: bash
+        run: chezmoi doctor


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs chezmoi and runs `chezmoi init` and `chezmoi doctor` on Linux, macOS, and Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa0fed064832d85775965d79b6f93