### PR TITLE
Add CI to validate chezmoi init across platforms

### DIFF
--- a/.github/workflows/chezmoi_init.yml
+++ b/.github/workflows/chezmoi_init.yml
@@ -1,0 +1,26 @@
+name: chezmoi init dry run
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  init:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install chezmoi
+        shell: bash
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/bin"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+      - name: Validate chezmoi init (dry run)
+        shell: bash
+        run: |
+          chezmoi init https://github.com/${{ github.repository }} --branch "$GITHUB_REF_NAME" --apply --dry-run


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `chezmoi init` in dry‑run mode
- validate the repository on Ubuntu, macOS and Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa6150870832d906cf8056c20a6ec